### PR TITLE
Merge feature/posts branch, changed post view and added custom article metadata

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -84,7 +84,11 @@
 				"quarto.quarto",
 				"REditorSupport.r",
 				"ms-python.python",
-				"ms-toolsai.jupyter"
+				"ms-toolsai.jupyter",
+				// user custom:
+				"GitHub.copilot-chat",
+				"GitHub.copilot",
+				"eamodio.gitlens"
 			]
 		}
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ menu:
       weight: 2
     - identifier: blog
       name: "Blog"
-      url: /archives/
+      url: /post/
       weight: 3
     - identifier: pubs
       name: "Publications"

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ menu:
       weight: 2
     - identifier: blog
       name: "Blog"
-      url: /post/
+      url: /post/ # alternatively /archives/
       weight: 3
     - identifier: pubs
       name: "Publications"
@@ -103,8 +103,8 @@ params:
   ShowShareButtons: false
   disableSpecial1stPost: false
   comments: false # https://github.com/adityatelange/hugo-PaperMod/wiki/Features#comments
-  hideSummary: false
-  hidemeta: false
+  hideSummary: false # no metadata description summary for posts in list.html, class="entry-content"
+  hidemeta: false # date and author below description
   showtoc: false
   tocopen: false
   ShowPostNavLinks: true # Adds a Previous / Next post suggestion under a single post

--- a/content/post/2021-03-15-tool-i-use/index.md
+++ b/content/post/2021-03-15-tool-i-use/index.md
@@ -3,6 +3,8 @@ title: Tools I Use
 author: Lennart Klein
 date: '2021-03-15'
 slug: [tools-i-use]
+description: "Desc Text Test!!" # Shown below title on post page
+summary: "Custom Summary Text!" # Shown in list view meta; see https://gohugo.io/content-management/summaries/#front-matter-summary
 categories:
   - Productivity
 tags:

--- a/layouts/_defaults/list.html
+++ b/layouts/_defaults/list.html
@@ -1,7 +1,6 @@
 {{- define "main" }}
 
 
-
 <!-- profileMode      -->
 {{- if (and site.Params.profileMode.enabled .IsHome) }}
 {{- partial "index_profile.html" . }}
@@ -69,12 +68,19 @@
 {{- end }}
 
 <article class="{{ $class }}">
-  {{- $isHidden := (site.Params.cover.hidden | default site.Params.cover.hiddenInList) }}
-  {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden) }}
+  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
   <header class="entry-header">
-    <h2>
+    <h2 class="entry-hint-parent">
       {{- .Title }}
-      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
     </h2>
   </header>
   {{- if (ne (.Param "hideSummary") true) }}

--- a/layouts/_defaults/list.html
+++ b/layouts/_defaults/list.html
@@ -1,11 +1,12 @@
 {{- define "main" }}
 
-
 <!-- profileMode      -->
 {{- if (and site.Params.profileMode.enabled .IsHome) }}
 {{- partial "index_profile.html" . }}
 {{- else }} {{/* if not profileMode */}}
+<!-- profileMode      -->
 
+<!-- List starts here -->
 {{- if not .IsHome | and .Title }}
 <header class="page-header">
   {{- partial "breadcrumbs.html" . }}
@@ -83,10 +84,14 @@
       {{- end }}
     </h2>
   </header>
+
+
+  <!-- Post Meta Description Summary -->
   {{- if (ne (.Param "hideSummary") true) }}
   <div class="entry-content">
     <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
   </div>
+  <!-- -> use "summary" YAML field -->
   {{- end }}
   {{- if not (.Param "hideMeta") }}
   <footer class="entry-footer">


### PR DESCRIPTION
- only need to change between `archives` and `post` in config to change the view type, I prefer the post view
- updated list.html
- figured out, that I can use the `summary` YAML field to add a custom summary, no further tweaking necessary. Thank god I found this page: [https://gohugo.io/content-management/summaries/#front-matter-summary](https://gohugo.io/content-management/summaries/#front-matter-summary)